### PR TITLE
fix: altText on PaginationLinks for case active page

### DIFF
--- a/src/components/ui/links/PaginationLinks.tsx
+++ b/src/components/ui/links/PaginationLinks.tsx
@@ -29,8 +29,14 @@ export const PaginationLinks = ({ page, path }: PaginationLinksProps) => {
       to={path}
       end
     >
-      <ScreenReadersOnly altText={page === "..." ? "More pages available" : "Go to page"} />
-      {page}
+      {
+        ({ isActive }) => (
+          <>
+            <ScreenReadersOnly altText={isActive ? "Active page" : page === "..." ? "More pages available" : "Go to page"} />
+            {page}
+          </>
+        )
+      }
     </StyledPaginationLink>
   )
 };


### PR DESCRIPTION
- Update the component `PaginationsLinks` to provide a more specific ScreenReadersOnly altText when the property `aria-current="page"` is true